### PR TITLE
Allow optional filename for bin

### DIFF
--- a/bin/cmd.js
+++ b/bin/cmd.js
@@ -7,7 +7,7 @@ var formatAsSpec = require('../')
 var stream = process.stdin
 
 if (process.argv[2]) {
-  stream = fs.createReadStream(process[argv[2]))
+  stream = fs.createReadStream(process[argv[2])
 }
 
 var input$ = parser.observeStream(stream)

--- a/bin/cmd.js
+++ b/bin/cmd.js
@@ -7,7 +7,7 @@ var formatAsSpec = require('../')
 var stream = process.stdin
 
 if (process.argv[2]) {
-  stream = fs.createReadStream(process[argv[2])
+  stream = fs.createReadStream(process[argv[2]])
 }
 
 var input$ = parser.observeStream(stream)

--- a/bin/cmd.js
+++ b/bin/cmd.js
@@ -1,9 +1,16 @@
 #!/usr/bin/env node
 
+var fs = require('fs')
 var parser = require('@tap-format/parser')
 var formatAsSpec = require('../')
 
-var input$ = parser.observeStream(process.stdin)
+var stream = process.stdin
+
+if (process.argv[2]) {
+  stream = fs.createReadStream(process[argv[2]))
+}
+
+var input$ = parser.observeStream(stream)
 
 formatAsSpec(input$).forEach(console.log.bind(console))
 

--- a/bin/cmd.js
+++ b/bin/cmd.js
@@ -7,7 +7,7 @@ var formatAsSpec = require('../')
 var stream = process.stdin
 
 if (process.argv[2]) {
-  stream = fs.createReadStream(process[argv[2]])
+  stream = fs.createReadStream(process.argv[2])
 }
 
 var input$ = parser.observeStream(stream)


### PR DESCRIPTION
Allow commands such as `tap-format-spec <filename>`. This is handy if you are using piping through `xargs`.